### PR TITLE
Fixed sending a null access token validation response

### DIFF
--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -214,7 +214,6 @@ public class TokenValidationHandler {
                 clientApp.setAccessTokenValidationResponse(responseDTO);
                 return clientApp;
             }
-            return clientApp;
         }
 
         // Add the token back to the cache in the case of a cache miss


### PR DESCRIPTION
Requesting for access token validation, for a token that should be valid sends a null validation response.
This PR fixes this issue.