### PR TITLE
Fixing IDENTITY-3205

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -88,8 +88,7 @@ public class ApplicationMgtUtil {
      * @throws IdentityApplicationManagementException
      */
     public static boolean isUserAuthorized(String applicationName) throws IdentityApplicationManagementException {
-        String tenantUser = CarbonContext.getThreadLocalCarbonContext().getUsername();
-        String user = MultitenantUtils.getTenantAwareUsername(tenantUser);
+        String user = CarbonContext.getThreadLocalCarbonContext().getUsername();
         String applicationRoleName = UserCoreUtil.addInternalDomainName(applicationName);
 
         try {


### PR DESCRIPTION
Removing redundant tenant aware username check. Since the username in ThreadLocalCarbonContext is always in the tenant aware manner.