### PR TITLE
Fix for IDENTITY-3235

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/InMemoryIdentityDataStore.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/InMemoryIdentityDataStore.java
@@ -21,6 +21,7 @@ import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.mgt.dto.UserIdentityClaimsDO;
 import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UserCoreConstants;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
@@ -48,8 +49,15 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
     public void store(UserIdentityClaimsDO userIdentityDTO, UserStoreManager userStoreManager)
             throws IdentityException {
         if (userIdentityDTO != null && userIdentityDTO.getUserName() != null) {
+
+            org.wso2.carbon.user.core.UserStoreManager store = (org.wso2.carbon.user.core.UserStoreManager) userStoreManager;
+
+            String domainName= store.getRealmConfiguration().getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+
+
+
             String key =
-                    userStoreManager.hashCode()+""+CarbonContext.getThreadLocalCarbonContext().getTenantId() +
+                    domainName+CarbonContext.getThreadLocalCarbonContext().getTenantId() +
                             userIdentityDTO.getUserName();
 //			if (cache.containsKey(key)) {
 //				invalidateCache(userIdentityDTO.getUserName());
@@ -67,7 +75,14 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
 
         Cache<String, UserIdentityClaimsDO> cache = getCache();
         if (userName != null && cache != null) {
-            return (UserIdentityClaimsDO) cache.get(userStoreManager.hashCode()+""+CarbonContext.getThreadLocalCarbonContext().getTenantId() +
+
+            org.wso2.carbon.user.core.UserStoreManager store = (org.wso2.carbon.user.core.UserStoreManager) userStoreManager;
+
+            String domainName= store.getRealmConfiguration().getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+
+
+
+            return (UserIdentityClaimsDO) cache.get(domainName+CarbonContext.getThreadLocalCarbonContext().getTenantId() +
                     userName);
         }
         return null;
@@ -79,7 +94,12 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
             return;
         }
 
-        cache.remove(userStoreManager+""+CarbonContext.getThreadLocalCarbonContext().getTenantId() + userName);
+        org.wso2.carbon.user.core.UserStoreManager store = (org.wso2.carbon.user.core.UserStoreManager) userStoreManager;
+
+        String domainName= store.getRealmConfiguration().getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+
+
+        cache.remove(domainName+CarbonContext.getThreadLocalCarbonContext().getTenantId() + userName);
 
 //		invalidateCache(userName);
     }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/InMemoryIdentityDataStore.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/InMemoryIdentityDataStore.java
@@ -49,7 +49,7 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
             throws IdentityException {
         if (userIdentityDTO != null && userIdentityDTO.getUserName() != null) {
             String key =
-                    CarbonContext.getThreadLocalCarbonContext().getTenantId() +
+                    userStoreManager.hashCode()+""+CarbonContext.getThreadLocalCarbonContext().getTenantId() +
                             userIdentityDTO.getUserName();
 //			if (cache.containsKey(key)) {
 //				invalidateCache(userIdentityDTO.getUserName());
@@ -67,7 +67,7 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
 
         Cache<String, UserIdentityClaimsDO> cache = getCache();
         if (userName != null && cache != null) {
-            return (UserIdentityClaimsDO) cache.get(CarbonContext.getThreadLocalCarbonContext().getTenantId() +
+            return (UserIdentityClaimsDO) cache.get(userStoreManager.hashCode()+""+CarbonContext.getThreadLocalCarbonContext().getTenantId() +
                     userName);
         }
         return null;
@@ -79,7 +79,7 @@ public class InMemoryIdentityDataStore extends UserIdentityDataStore {
             return;
         }
 
-        cache.remove(CarbonContext.getThreadLocalCarbonContext().getTenantId() + userName);
+        cache.remove(userStoreManager+""+CarbonContext.getThreadLocalCarbonContext().getTenantId() + userName);
 
 //		invalidateCache(userName);
     }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserStoreBasedIdentityDataStore.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserStoreBasedIdentityDataStore.java
@@ -141,7 +141,7 @@ public class UserStoreBasedIdentityDataStore extends InMemoryIdentityDataStore {
 
             Cache<String, UserIdentityClaimsDO> cache = getCache();
             if (cache != null) {
-                cache.put(tenantId + userName, userIdentityDTO);
+                cache.put(userStoreManager.hashCode()+""+tenantId + userName, userIdentityDTO);
             }
             return userIdentityDTO;
         }

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserStoreBasedIdentityDataStore.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/store/UserStoreBasedIdentityDataStore.java
@@ -139,9 +139,14 @@ public class UserStoreBasedIdentityDataStore extends InMemoryIdentityDataStore {
             int tenantId = CarbonContext.getThreadLocalCarbonContext().getTenantId();
             userIdentityDTO.setTenantId(tenantId);
 
+            org.wso2.carbon.user.core.UserStoreManager store = (org.wso2.carbon.user.core.UserStoreManager) userStoreManager;
+
+            String domainName= store.getRealmConfiguration().getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+
+
             Cache<String, UserIdentityClaimsDO> cache = getCache();
             if (cache != null) {
-                cache.put(userStoreManager.hashCode()+""+tenantId + userName, userIdentityDTO);
+                cache.put(domainName+tenantId + userName, userIdentityDTO);
             }
             return userIdentityDTO;
         }


### PR DESCRIPTION
Multiple userstores containing the same user name can now lock only the relevant userstore domain of failed login attempts if the domain was specified by the user. 