### PR TITLE
correcting javax cache import version in entitlement proxy

### DIFF
--- a/components/agents/org.wso2.carbon.identity.entitlement.proxy/pom.xml
+++ b/components/agents/org.wso2.carbon.identity.entitlement.proxy/pom.xml
@@ -159,7 +159,7 @@
                         <Import-Package>
                             !javax.xml.namespace,
                             javax.xml.parsers,
-                            javax.cache; version="${carbon.kernel.package.import.version.range}",
+                            javax.cache,
                             javax.crypto,
                             org.apache.axiom.om.*; version="${axiom.osgi.version.range}",
                             org.apache.axis2.*; version="${axis2.osgi.version.range}",


### PR DESCRIPTION
In Carbon 4.4.0 kernel, javax.cache is exported without a version[1]. But in carbon-identity it is imported with a version [4.4.0,4.5.0) which leads to following build error in ESB p2-profile.

Cannot complete the install because one or more required items could not be found.
 Software being installed: WSO2 Carbon - XACML Mediation Feature 4.4.1.SNAPSHOT (org.wso2.carbon.identity.xacml.mediator.feature.group 4.4.1.SNAPSHOT)
 Missing requirement: org.wso2.carbon.identity.entitlement.proxy 4.4.1 (org.wso2.carbon.identity.entitlement.proxy 4.4.1) requires 'package javax.cache [4.4.0,4.5.0)' but it could not be found
 Cannot satisfy dependency:
  From: org.wso2.carbon.identity.entitlement.mediator 4.4.1.SNAPSHOT (org.wso2.carbon.identity.entitlement.mediator 4.4.1.SNAPSHOT)
  To: package org.wso2.carbon.identity.entitlement.proxy [4.4.0,5.0.0)
 Cannot satisfy dependency:
  From: WSO2 Carbon - XACML Mediation Feature 4.4.1.SNAPSHOT (org.wso2.carbon.identity.xacml.mediator.feature.group 4.4.1.SNAPSHOT)
  To: org.wso2.carbon.identity.entitlement.mediator [4.4.1.SNAPSHOT]


[1] https://github.com/wso2/carbon4-kernel/blob/master/core/javax.cache/pom.xml