### PR TITLE
IDENTITY-3389 Move dependency versions from component level poms to master pom

### DIFF
--- a/components/application-authenticators/org.wso2.carbon.identity.application.authenticator.fido/pom.xml
+++ b/components/application-authenticators/org.wso2.carbon.identity.application.authenticator.fido/pom.xml
@@ -85,7 +85,7 @@
                             org.wso2.carbon.identity.application.authentication.framework.exception,
                             org.wso2.carbon.identity.application.authentication.framework.model,
                             org.wso2.carbon.identity.base, org.wso2.carbon.identity.core.util, org.wso2.carbon.user.api,
-                            org.wso2.carbon.user.core.service, org.wso2.carbon.user.core.tenant, org.xml.sax, sun.misc
+                            org.wso2.carbon.user.core.service, org.wso2.carbon.user.core.tenant, org.xml.sax, sun.misc;resolution:=optional,
                         </Import-Package>
                         <Embed-Dependency>
                             jackson-core|guava|u2flib-server-core|jackson-databind|jackson-annotations

--- a/components/carbon-authenticators/saml2-sso-authenticator/org.wso2.carbon.identity.authenticator.saml2.sso.ui/pom.xml
+++ b/components/carbon-authenticators/saml2-sso-authenticator/org.wso2.carbon.identity.authenticator.saml2.sso.ui/pom.xml
@@ -110,8 +110,6 @@
 
                             org.wso2.carbon.identity.authenticator.saml2.sso.common.*;
                             version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.identity.authenticator.saml2.sso.common.client;
-                            version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.sso.saml.stub.*;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.authenticator.saml2.sso.stub;


### PR DESCRIPTION
This PR fixed product-is build failure happens due to moving SAML2SSOAuthenticationClient from commons to ui component.
Before merging this, https://github.com/wso2/carbon-identity/pull/542 should be reverted.