### PR TITLE
Fix for identity-3171 to populate AttributeServiceIndex correctly

### DIFF
--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdmin.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/admin/SAMLSSOConfigAdmin.java
@@ -78,7 +78,7 @@ public class SAMLSSOConfigAdmin {
         serviceProviderDO.setDoSignResponse(serviceProviderDTO.isDoSignResponse());
         serviceProviderDO.setDoSignAssertions(serviceProviderDTO.isDoSignAssertions());
         serviceProviderDO.setNameIdClaimUri(serviceProviderDTO.getNameIdClaimUri());
-        serviceProviderDO.setEnableAttributesByDefault(serviceProviderDTO.isEnableAttributesByDefault());
+
 
         if (serviceProviderDTO.getNameIDFormat() == null) {
             serviceProviderDTO.setNameIDFormat(NameIdentifier.EMAIL);
@@ -96,8 +96,13 @@ public class SAMLSSOConfigAdmin {
             } else {
                 serviceProviderDO.setAttributeConsumingServiceIndex(Integer.toString(IdentityUtil.getRandomInteger()));
             }
+            serviceProviderDO.setEnableAttributesByDefault(serviceProviderDTO.isEnableAttributesByDefault());
         } else {
             serviceProviderDO.setAttributeConsumingServiceIndex("");
+            if (serviceProviderDO.isEnableAttributesByDefault()) {
+                log.warn("Enable Attribute Profile must be selected to activate it by default. EnableAttributesByDefault will be disabled.");
+            }
+            serviceProviderDO.setEnableAttributesByDefault(false);
         }
 
         if (serviceProviderDTO.getRequestedAudiences() != null && serviceProviderDTO.getRequestedAudiences().length != 0) {

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java
@@ -61,12 +61,6 @@ public class SPInitSSOAuthnRequestProcessor {
                         SAMLSSOConstants.StatusCodes.REQUESTOR_ERROR, msg);
             }
 
-            if (serviceProviderConfigs.isEnableAttributesByDefault() && serviceProviderConfigs.getAttributeConsumingServiceIndex() != null) {
-                authnReqDTO.setAttributeConsumingServiceIndex(Integer
-                        .parseInt(serviceProviderConfigs
-                                .getAttributeConsumingServiceIndex()));
-            }
-
             // reading the service provider configs
             populateServiceProviderConfigs(serviceProviderConfigs, authnReqDTO);
 

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -887,7 +887,7 @@ public class SAMLSSOUtil {
                 throw new IdentityException("Illegal access to class: "
                         + IdentityUtil.getProperty("SSOService.SAMLSSOSigner"), e);
             } catch (Exception e) {
-                if(log.isDebugEnabled()){
+                if (log.isDebugEnabled()) {
                     log.debug("Error while validating XML signature.", e);
                 }
             }
@@ -930,25 +930,35 @@ public class SAMLSSOUtil {
             } catch (IdentityException e) {
                 request = (AuthnRequestImpl) SAMLSSOUtil.unmarshall(SAMLSSOUtil
                         .decodeForPost(authnReqDTO.getRequestMessageString()));
-                if(log.isDebugEnabled()){
+                if (log.isDebugEnabled()) {
                     log.debug("Error while decoding authentication request.", e);
                 }
             }
 
             if (request.getAttributeConsumingServiceIndex() == null) {
-                if (authnReqDTO.getAttributeConsumingServiceIndex() != 0) {
-                    index = authnReqDTO.getAttributeConsumingServiceIndex();
-                    spDO.setAttributeConsumingServiceIndex(String.valueOf(index));
+                //SP has not provide a AttributeConsumingServiceIndex in the authnReqDTO
+                if (StringUtils.isNotBlank(spDO.getAttributeConsumingServiceIndex())) {
+                    if (spDO.isEnableAttributesByDefault()) {
+                        index = Integer.parseInt(spDO.getAttributeConsumingServiceIndex());
+                    } else {
+                        return null;
+                    }
                 } else {
-                    return null; // not requesting for attributes
+                    return null;
                 }
             } else {
+                //SP has provide a AttributeConsumingServiceIndex in the authnReqDTO
                 index = request.getAttributeConsumingServiceIndex();
             }
         } else {
-            index = authnReqDTO.getAttributeConsumingServiceIndex();
-            if (index != 0) {
-                spDO.setAttributeConsumingServiceIndex(String.valueOf(index));
+            if (StringUtils.isNotBlank(spDO.getAttributeConsumingServiceIndex())) {
+                if (spDO.isEnableAttributesByDefault()) {
+                    index = Integer.parseInt(spDO.getAttributeConsumingServiceIndex());
+                } else {
+                    return null;
+                }
+            } else {
+                return null;
             }
 
         }
@@ -1134,7 +1144,7 @@ public class SAMLSSOUtil {
                         normalized.append(percentCode);
                 } catch (UnsupportedEncodingException e) {
                     normalized.append(percentCode);
-                    if(log.isDebugEnabled()){
+                    if (log.isDebugEnabled()) {
                         log.debug("Unsupported Encoding exception while decoding percent code.", e);
                     }
                 }


### PR DESCRIPTION
Fix for Identity-3171 issue. "authnReqDTO" now contains AttributeConsumingServiceIndex read from SAML Request.