### PR TITLE
correcting the resultset index for scopes string from 3 to 8

### DIFF
--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenMgtDAO.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/dao/TokenMgtDAO.java
@@ -473,7 +473,7 @@ public class TokenMgtDAO {
                     dataDO.setTokenId(tokenId);
                     accessTokenDOMap.put(accessToken, dataDO);
                 } else {
-                    String scope = resultSet.getString(3).trim();
+                    String scope = resultSet.getString(8).trim();
                     AccessTokenDO accessTokenDO = accessTokenDOMap.get(accessToken);
                     accessTokenDO.setScope((String[]) ArrayUtils.add(accessTokenDO.getScope(), scope));
                 }


### PR DESCRIPTION
When retrieving the scopes string for the access token the index to access from the result set is 8 and not 3. 