### PR TITLE
fix for IDENTITY-3468

### DIFF
--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/EntitlementPolicyAdminService.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/EntitlementPolicyAdminService.java
@@ -617,6 +617,9 @@ public class EntitlementPolicyAdminService {
     public String[] getPolicyVersions(String policyId) throws EntitlementException {
 
         String[] versions = EntitlementAdminEngine.getInstance().getVersionManager().getVersions(policyId);
+        if(versions == null){
+            return new String[0];
+        }
         Arrays.sort(versions);
         return versions;
 

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/EntitlementPolicyAdminService.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/EntitlementPolicyAdminService.java
@@ -618,7 +618,7 @@ public class EntitlementPolicyAdminService {
 
         String[] versions = EntitlementAdminEngine.getInstance().getVersionManager().getVersions(policyId);
         if(versions == null){
-            return new String[0];
+            throw new EntitlementException("Error obtaining policy versions");
         }
         Arrays.sort(versions);
         return versions;

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/EntitlementPolicyAdminService.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/EntitlementPolicyAdminService.java
@@ -51,6 +51,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -615,7 +616,9 @@ public class EntitlementPolicyAdminService {
      */
     public String[] getPolicyVersions(String policyId) throws EntitlementException {
 
-        return EntitlementAdminEngine.getInstance().getVersionManager().getVersions(policyId);
+        String[] versions = EntitlementAdminEngine.getInstance().getVersionManager().getVersions(policyId);
+        Arrays.sort(versions);
+        return versions;
 
     }
 


### PR DESCRIPTION
Fix for possible random ordering of policy versions reproduicible in oracledb