### PR TITLE
Add the apache commons-collection dependency in agents. Commented sol…

### DIFF
--- a/components/agents/org.wso2.carbon.identity.sso.agent/pom.xml
+++ b/components/agents/org.wso2.carbon.identity.sso.agent/pom.xml
@@ -35,6 +35,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>commons-collections.wso2</groupId>
+            <artifactId>commons-collections</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity</groupId>
             <artifactId>org.wso2.carbon.identity.core</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -1894,7 +1894,7 @@
         <google.guava.wso2.version>12.0.0.wso2v1</google.guava.wso2.version>
         <google.guava.version>15.0</google.guava.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <version.solr>1.4.1.wso2v1</version.solr>
+        <!--<version.solr>1.4.1.wso2v1</version.solr>-->
         <derby.version>10.4.2.0</derby.version>
         <activation.version>1.1</activation.version>
         <javamail.version>1.4</javamail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1894,7 +1894,6 @@
         <google.guava.wso2.version>12.0.0.wso2v1</google.guava.wso2.version>
         <google.guava.version>15.0</google.guava.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <!--<version.solr>1.4.1.wso2v1</version.solr>-->
         <derby.version>10.4.2.0</derby.version>
         <activation.version>1.1</activation.version>
         <javamail.version>1.4</javamail.version>


### PR DESCRIPTION
Add the apache commons-collection dependency in agents. It is necessary to run the travelocity app. Without proper dependancy it gives error.
Commented solr version in root pom. No usages in carbon-identity and the latest version is already packed. 