### PR TITLE
Fixing IDENTITY-3540

### DIFF
--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/SingleLogoutMessageBuilder.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/SingleLogoutMessageBuilder.java
@@ -109,8 +109,9 @@ public class SingleLogoutMessageBuilder {
         return logoutReq;
     }
 
-    public LogoutResponse buildLogoutResponse(String id, String status, String statMsg, String destination, String
-            tenantDomain, String responseSigningAlgorithmUri, String responseDigestAlgoUri) throws IdentityException {
+    public LogoutResponse buildLogoutResponse(String id, String status, String statMsg, String destination, boolean
+            isSignResponse, String tenantDomain, String responseSigningAlgorithmUri, String responseDigestAlgoUri)
+            throws IdentityException {
 
         LogoutResponse logoutResp = new LogoutResponseBuilder().buildObject();
         logoutResp.setID(SAMLSSOUtil.createID());
@@ -121,7 +122,7 @@ public class SingleLogoutMessageBuilder {
         logoutResp.setDestination(destination);
 
         // Currently, does not sign the error response since this message pass through a url to the error page
-        if (SAMLSSOConstants.StatusCodes.SUCCESS_CODE.equals(status)) {
+        if (isSignResponse && SAMLSSOConstants.StatusCodes.SUCCESS_CODE.equals(status)) {
             int tenantId;
             if (StringUtils.isEmpty(tenantDomain)) {
                 tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOReqValidationResponseDTO.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOReqValidationResponseDTO.java
@@ -44,6 +44,7 @@ public class SAMLSSOReqValidationResponseDTO implements Serializable {
     private boolean logoutFromAuthFramework;
     private boolean isIdPInitSLO;
     private String returnToURL;
+    private boolean doSignResponse;
     private String signingAlgorithmUri;
     private String digestAlgorithmUri;
 
@@ -262,5 +263,19 @@ public class SAMLSSOReqValidationResponseDTO implements Serializable {
 
     public void setReturnToURL(String returnToURL) {
         this.returnToURL = returnToURL;
+    }
+
+    /**
+     * @return the doSignResponse
+     */
+    public boolean isDoSignResponse() {
+        return doSignResponse;
+    }
+
+    /**
+     * @param doSignResponse the doSignResponse to set
+     */
+    public void setDoSignResponse(boolean doSignResponse) {
+        this.doSignResponse = doSignResponse;
     }
 }

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitLogoutRequestProcessor.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitLogoutRequestProcessor.java
@@ -226,6 +226,7 @@ public class SPInitLogoutRequestProcessor {
                         singleLogoutReqDTOs.add(logoutReqDTO);
                     } else {
                         reqValidationResponseDTO.setIssuer(value.getIssuer());
+                        reqValidationResponseDTO.setDoSignResponse(value.isDoSignResponse());
                         reqValidationResponseDTO.setSigningAlgorithmUri(value.getSigningAlgorithmUri());
                         reqValidationResponseDTO.setDigestAlgorithmUri(value.getDigestAlgorithmUri());
                         if (StringUtils.isNotBlank(value.getSloResponseURL())) {
@@ -239,11 +240,16 @@ public class SPInitLogoutRequestProcessor {
                 reqValidationResponseDTO.setLogoutRespDTO(singleLogoutReqDTOs.toArray(
                         new SingleLogoutRequestDTO[singleLogoutReqDTOs.size()]));
 
-                LogoutResponse logoutResponse = logoutMsgBuilder.buildLogoutResponse(logoutRequest.getID(),
-                        SAMLSSOConstants.StatusCodes.SUCCESS_CODE, null, reqValidationResponseDTO
-                                .getAssertionConsumerURL(), SAMLSSOUtil.getTenantDomainFromThreadLocal(),
-                        reqValidationResponseDTO.getSigningAlgorithmUri(), reqValidationResponseDTO
-                                .getDigestAlgorithmUri());
+                LogoutResponse logoutResponse = logoutMsgBuilder.buildLogoutResponse(
+                        logoutRequest.getID(),
+                        SAMLSSOConstants.StatusCodes.SUCCESS_CODE,
+                        null,
+                        reqValidationResponseDTO.getAssertionConsumerURL(),
+                        reqValidationResponseDTO.isDoSignResponse(),
+                        SAMLSSOUtil.getTenantDomainFromThreadLocal(),
+                        reqValidationResponseDTO.getSigningAlgorithmUri(),
+                        reqValidationResponseDTO.getDigestAlgorithmUri());
+
                 reqValidationResponseDTO.setLogoutResponse(SAMLSSOUtil.encode(SAMLSSOUtil.marshall(logoutResponse)));
                 reqValidationResponseDTO.setValid(true);
             }
@@ -269,7 +275,7 @@ public class SPInitLogoutRequestProcessor {
             throws IdentityException {
         SAMLSSOReqValidationResponseDTO reqValidationResponseDTO = new SAMLSSOReqValidationResponseDTO();
         LogoutResponse logoutResp = new SingleLogoutMessageBuilder().buildLogoutResponse(id, status, statMsg,
-                destination, null, responseSigningAlgorithmUri, responseDigestAlgorithmUri);
+                destination, false, null, responseSigningAlgorithmUri, responseDigestAlgorithmUri);
         reqValidationResponseDTO.setLogOutReq(true);
         reqValidationResponseDTO.setValid(false);
         try {

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/processors/SPInitSSOAuthnRequestProcessor.java
@@ -149,6 +149,7 @@ public class SPInitSSOAuthnRequestProcessor {
                     spDO.setIdPInitSLOEnabled(authnReqDTO.isIdPInitSLOEnabled());
                     spDO.setAssertionConsumerUrls(authnReqDTO.getAssertionConsumerURLs());
                     spDO.setIdpInitSLOReturnToURLs(authnReqDTO.getIdpInitSLOReturnToURLs());
+                    spDO.setDoSignResponse(authnReqDTO.isDoSignResponse());
                     spDO.setSigningAlgorithmUri(authnReqDTO.getSigningAlgorithmUri());
                     spDO.setDigestAlgorithmUri(authnReqDTO.getDigestAlgorithmUri());
                     sessionPersistenceManager.persistSession(sessionIndexId,


### PR DESCRIPTION
Making SAML logout response signing done according to the configurations given when registering the SAML service provider.

More specifically now the logout response will be signed only if "Enable Response Signing" configuration is set.