### PR TITLE
Fixing serialization in carbon-identity

### DIFF
--- a/components/agents/org.wso2.carbon.identity.entitlement.proxy/src/main/org/wso2/carbon/identity/entitlement/proxy/IdentityCacheEntry.java
+++ b/components/agents/org.wso2.carbon.identity.entitlement.proxy/src/main/org/wso2/carbon/identity/entitlement/proxy/IdentityCacheEntry.java
@@ -29,7 +29,8 @@ import java.util.Date;
  */
 public class IdentityCacheEntry implements Serializable {
 
-    private static final long serialVersionUID = 3746964700806693258L;
+    private static final long serialVersionUID = 7239122598310553180L;
+
     private String cacheEntry;
     private String[] cacheEntryArray;
     private int hashEntry;

--- a/components/agents/org.wso2.carbon.identity.entitlement.proxy/src/main/org/wso2/carbon/identity/entitlement/proxy/IdentityCacheKey.java
+++ b/components/agents/org.wso2.carbon.identity.entitlement.proxy/src/main/org/wso2/carbon/identity/entitlement/proxy/IdentityCacheKey.java
@@ -27,7 +27,8 @@ import java.io.Serializable;
  */
 public class IdentityCacheKey implements Serializable {
 
-    private static final long serialVersionUID = -7700438046096986522L;
+    private static final long serialVersionUID = 1806955328379952612L;
+
     private String key;
 
     public IdentityCacheKey(String key) {

--- a/components/agents/org.wso2.carbon.identity.sso.agent/src/main/java/org/wso2/carbon/identity/sso/agent/bean/LoggedInSessionBean.java
+++ b/components/agents/org.wso2.carbon.identity.sso.agent/src/main/java/org/wso2/carbon/identity/sso/agent/bean/LoggedInSessionBean.java
@@ -34,7 +34,9 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
-public class LoggedInSessionBean implements Serializable{
+public class LoggedInSessionBean implements Serializable {
+
+    private static final long serialVersionUID = 7762835859870143767L;
 
     private OpenID openId;
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/cache/CacheEntry.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/cache/CacheEntry.java
@@ -26,8 +26,8 @@ import java.io.Serializable;
  */
 public abstract class CacheEntry implements Serializable {
 
+    private static final long serialVersionUID = -7349132415139486164L;
+
     protected CacheEntry() {
     }
-
-    private static final long serialVersionUID = 1565107988768069823L;
 }

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/cache/CacheKey.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/cache/CacheKey.java
@@ -28,7 +28,7 @@ import java.io.Serializable;
  */
 public abstract class CacheKey implements Serializable {
 
-    private static final long serialVersionUID = -5992905297718363173L;
+    private static final long serialVersionUID = 659646764466611338L;
 
     protected String tenantDomain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ApplicationBasicInfo.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ApplicationBasicInfo.java
@@ -21,9 +21,6 @@ import java.io.Serializable;
 
 public class ApplicationBasicInfo implements Serializable {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -16127229981193883L;
 
     private String applicationName;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ApplicationPermission.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ApplicationPermission.java
@@ -25,10 +25,7 @@ import java.util.Iterator;
 
 public class ApplicationPermission implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5921176623905192883L;
+    private static final long serialVersionUID = -2607860389906543495L;
 
     private String value;
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/AuthenticationStep.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/AuthenticationStep.java
@@ -31,10 +31,7 @@ import java.util.Set;
 
 public class AuthenticationStep implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4001996659290645507L;
+    private static final long serialVersionUID = 497647508006862448L;
 
     private int stepOrder = 1;
     private LocalAuthenticatorConfig[] localAuthenticatorConfigs = new LocalAuthenticatorConfig[0];

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/CertData.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/CertData.java
@@ -23,9 +23,6 @@ import java.math.BigInteger;
 
 public class CertData implements Serializable {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 2096222055741114879L;
 
     private String alias;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/Claim.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/Claim.java
@@ -25,10 +25,7 @@ import java.util.Iterator;
 
 public class Claim implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -9123587946522643637L;
+    private static final long serialVersionUID = 7311770592520078910L;
 
     private String claimUri;
     private int claimId;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClaimConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClaimConfig.java
@@ -27,10 +27,7 @@ import java.util.List;
 
 public class ClaimConfig implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3927992808243347563L;
+    private static final long serialVersionUID = 94689128465184610L;
 
     private String roleClaimURI;
     private String userClaimURI;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClaimMapping.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ClaimMapping.java
@@ -26,10 +26,7 @@ import java.util.Iterator;
 
 public class ClaimMapping implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -2530192004968748230L;
+    private static final long serialVersionUID = -5329129991600888989L;
 
     private Claim localClaim;
     private Claim remoteClaim;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/FederatedAuthenticatorConfig.java
@@ -31,10 +31,7 @@ import java.util.Set;
 
 public class FederatedAuthenticatorConfig implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 6562346450443426344L;
+    private static final long serialVersionUID = -2361107623257323257L;
 
     protected String name;
     protected String displayName;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/IdentityProvider.java
@@ -34,10 +34,7 @@ import java.util.Set;
 
 public class IdentityProvider implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3348487050533568857L;
+    private static final long serialVersionUID = 2199048941051702943L;
 
     private static final Log log = LogFactory.getLog(IdentityProvider.class);
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationConfig.java
@@ -28,10 +28,7 @@ import java.util.List;
 
 public class InboundAuthenticationConfig implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8966626233502458748L;
+    private static final long serialVersionUID = 2768674144259414077L;
 
     private transient InboundAuthenticationRequestConfig[] inboundAuthenticationRequestConfigs = new
             InboundAuthenticationRequestConfig[0];

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationRequestConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundAuthenticationRequestConfig.java
@@ -31,10 +31,7 @@ import java.util.Set;
 
 public class InboundAuthenticationRequestConfig implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -4619706374988196634L;
+    private static final long serialVersionUID = -62766721187073002L;
 
     private String inboundAuthKey;
     private String inboundAuthType;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundProvisioningConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/InboundProvisioningConfig.java
@@ -25,10 +25,7 @@ import java.util.Iterator;
 
 public class InboundProvisioningConfig implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7268191162277514923L;
+    private static final long serialVersionUID = -7320364749026206151L;
 
     private String provisioningUserStore;
     private boolean provisioningEnabled;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/JustInTimeProvisioningConfig.java
@@ -25,10 +25,7 @@ import java.util.Iterator;
 
 public class JustInTimeProvisioningConfig extends InboundProvisioningConfig implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 5899735295450764828L;
+    private static final long serialVersionUID = 6754801699494009980L;
 
     private String userStoreClaimUri;
 

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAndOutboundAuthenticationConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAndOutboundAuthenticationConfig.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 public class LocalAndOutboundAuthenticationConfig implements Serializable {
 
-    private static final long serialVersionUID = -932772940989929376L;
+    private static final long serialVersionUID = 6552125621314155291L;
 
     private AuthenticationStep[] authenticationSteps = new AuthenticationStep[0];
     private String authenticationType;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalAuthenticatorConfig.java
@@ -30,10 +30,7 @@ import java.util.Set;
 
 public class LocalAuthenticatorConfig implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -1294054850307327027L;
+    private static final long serialVersionUID = 3363298518257599291L;
 
     protected String name;
     protected String displayName;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalRole.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/LocalRole.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 
 public class LocalRole implements Serializable {
 
-    private static final long serialVersionUID = 44L;
+    private static final long serialVersionUID = -1986741675509417413L;
 
     /**
      * The mapped role name of the IdP role at this local IdP end

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/OutboundProvisioningConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/OutboundProvisioningConfig.java
@@ -31,10 +31,7 @@ import java.util.Set;
 
 public class OutboundProvisioningConfig implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1653270395614833536L;
+    private static final long serialVersionUID = 3669233357817378229L;
 
     private IdentityProvider[] provisioningIdentityProviders = new IdentityProvider[0];
     private String[] provisionByRoleList;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/PermissionsAndRoleConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/PermissionsAndRoleConfig.java
@@ -28,10 +28,7 @@ import java.util.List;
 
 public class PermissionsAndRoleConfig implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7994146492198021069L;
+    private static final long serialVersionUID = 784509684062361809L;
 
     private ApplicationPermission[] permissions = new ApplicationPermission[0];
     private RoleMapping[] roleMappings = new RoleMapping[0];

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/Property.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/Property.java
@@ -25,10 +25,7 @@ import java.util.Iterator;
 
 public class Property implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 3014011808515883129L;
+    private static final long serialVersionUID = 2423059969331364604L;
 
     private String name;
     private String value;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ProvisioningConnectorConfig.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ProvisioningConnectorConfig.java
@@ -32,10 +32,7 @@ import java.util.List;
 
 public class ProvisioningConnectorConfig implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 8270617885506096420L;
+    private static final long serialVersionUID = -4569973060498183209L;
 
     protected Property[] provisioningProperties = new Property[0];
     protected String name;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/RoleMapping.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/RoleMapping.java
@@ -25,10 +25,7 @@ import java.util.Iterator;
 
 public class RoleMapping implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -2116444950898503844L;
+    private static final long serialVersionUID = 4838992846277456900L;
 
     private LocalRole localRole = null;
     private String remoteRole = null;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ServiceProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ServiceProvider.java
@@ -29,10 +29,7 @@ import java.util.List;
 
 public class ServiceProvider implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = 1018969519851610663L;
+    private static final long serialVersionUID = 4754526832588478582L;
     private static final Log log = LogFactory.getLog(ServiceProvider.class);
 
     private int applicationID = 0;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ThreadLocalProvisioningServiceProvider.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/ThreadLocalProvisioningServiceProvider.java
@@ -24,10 +24,7 @@ import java.io.Serializable;
 
 public class ThreadLocalProvisioningServiceProvider implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -486701265390312767L;
+    private static final long serialVersionUID = 8869773391988526466L;
 
     private String serviceProviderName;
     private String claimDialect;

--- a/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/User.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.common/src/main/java/org/wso2/carbon/identity/application/common/model/User.java
@@ -26,10 +26,8 @@ import java.util.Iterator;
 
 public class User implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -3605277664796682611L;
+    private static final long serialVersionUID = 928301275168169633L;
+
     protected String tenantDomain;
     protected String userStoreDomain;
     protected String userName;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticatorStateInfo.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AuthenticatorStateInfo.java
@@ -22,4 +22,5 @@ import java.io.Serializable;
 
 public abstract class AuthenticatorStateInfo implements Serializable {
 
+    private static final long serialVersionUID = -1137594892169989451L;
 }

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/AuthenticatorConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/AuthenticatorConfig.java
@@ -33,7 +33,7 @@ import java.util.Map;
  */
 public class AuthenticatorConfig implements Serializable {
 
-    private static final long serialVersionUID = 2811339541117886651L;
+    private static final long serialVersionUID = 4391415512399764048L;
 
     private String name;
     private boolean enabled;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/ExternalIdPConfig.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 public class ExternalIdPConfig implements Serializable {
 
-    private static final long serialVersionUID = -8973637869824303767L;
+    private static final long serialVersionUID = 8406982734621371639L;
 
     private IdentityProvider identityProvider;
     private ClaimConfig claimConfiguration;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/SequenceConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/SequenceConfig.java
@@ -31,7 +31,7 @@ import java.util.Map;
  */
 public class SequenceConfig implements Serializable {
 
-    private static final long serialVersionUID = 3316149796008510127L;
+    private static final long serialVersionUID = 6822366703354668075L;
 
     private String name;
     private boolean isForceAuthn;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/StepConfig.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/config/model/StepConfig.java
@@ -30,7 +30,7 @@ import java.util.List;
  */
 public class StepConfig implements Serializable {
 
-    private static final long serialVersionUID = 9139242244264058990L;
+    private static final long serialVersionUID = 7271079506748466841L;
 
     private int order;
     private String loginPage;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/AuthenticationContext.java
@@ -36,7 +36,7 @@ import java.util.Map;
  */
 public class AuthenticationContext implements Serializable {
 
-    private static final long serialVersionUID = -7007412857088788541L;
+    private static final long serialVersionUID = 6438291349985653301L;
 
     private String contextIdentifier;
     private String sessionIdentifier;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/SessionContext.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/context/SessionContext.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 public class SessionContext implements Serializable {
 
-    private static final long serialVersionUID = -5797408810833645408L;
+    private static final long serialVersionUID = -1217614650620644670L;
 
     private Map<String, SequenceConfig> authenticatedSequences = new HashMap<String, SequenceConfig>();
     private Map<String, AuthenticatedIdPData> authenticatedIdPs = new HashMap<String, AuthenticatedIdPData>();

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedIdPData.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedIdPData.java
@@ -24,7 +24,7 @@ import java.io.Serializable;
 
 public class AuthenticatedIdPData implements Serializable {
 
-    private static final long serialVersionUID = -1778751155155790874L;
+    private static final long serialVersionUID = 5576595024956777804L;
 
     private String idpName;
     private AuthenticatorConfig authenticator;

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticationRequest.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticationRequest.java
@@ -30,7 +30,9 @@ import java.util.Map;
  */
 @SuppressWarnings("unused")
 public class AuthenticationRequest implements Serializable {
-    private static final long serialVersionUID = -5407487459807348541L;
+
+    private static final long serialVersionUID = 8131978212432223682L;
+
     /**
      * Type of the request coming to framework eg:saml
      */

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticationResult.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticationResult.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 public class AuthenticationResult implements Serializable {
 
-    private static final long serialVersionUID = -2555005773164092641L;
+    private static final long serialVersionUID = 7468735345445470413L;
 
     private boolean authenticated;
     private AuthenticatedUser subject;

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/PolicyOrderComparator.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/PolicyOrderComparator.java
@@ -29,6 +29,8 @@ import java.util.Comparator;
  */
 public class PolicyOrderComparator implements Serializable, Comparator {
 
+    private static final long serialVersionUID = -4125227115004608650L;
+
     @Override
     public int compare(Object o1, Object o2) {
 

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/StatusHolderComparator.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/StatusHolderComparator.java
@@ -29,6 +29,8 @@ import java.util.Comparator;
  */
 public class StatusHolderComparator implements Serializable, Comparator {
 
+    private static final long serialVersionUID = -6675867912216533133L;
+
     @Override
     public int compare(Object o1, Object o2) {
 

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/cache/IdentityCacheEntry.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/cache/IdentityCacheEntry.java
@@ -29,7 +29,8 @@ import java.util.Set;
  */
 public class IdentityCacheEntry implements Serializable {
 
-    private static final long serialVersionUID = 3746964700806693258L;
+    private static final long serialVersionUID = 6982031255566292798L;
+
     private String cacheEntry;
     private Set<String> cacheEntrySet;
     private String[] cacheEntryArray;

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/cache/IdentityCacheKey.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/cache/IdentityCacheKey.java
@@ -25,7 +25,8 @@ import java.io.Serializable;
  */
 public class IdentityCacheKey implements Serializable {
 
-    private static final long serialVersionUID = -7700438046096986522L;
+    private static final long serialVersionUID = 3413834923591132863L;
+
     private int tenantId;
     private String key;
 

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/cache/PolicyStatus.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/cache/PolicyStatus.java
@@ -7,6 +7,8 @@ import java.io.Serializable;
  */
 public class PolicyStatus implements Serializable {
 
+    private static final long serialVersionUID = -5173389109938987102L;
+
     private String policyId = null;
     private int statusCount = 0;
     private String policyAction;

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/policy/collection/DefaultPolicyCollection.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/policy/collection/DefaultPolicyCollection.java
@@ -347,6 +347,9 @@ public class DefaultPolicyCollection implements PolicyCollection {
      * additions or fetches.
      */
     static class VersionComparator implements Serializable, Comparator<AbstractPolicy> {
+
+        private static final long serialVersionUID = 1136846256293162005L;
+
         public int compare(AbstractPolicy o1, AbstractPolicy o2) {
             // we swap the parameters so that sorting goes largest to smallest
             String v1 = ((AbstractPolicy) o2).getVersion();

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/policy/search/SearchResult.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/policy/search/SearchResult.java
@@ -28,6 +28,7 @@ import java.io.Serializable;
 public class SearchResult implements Serializable {
 
     private static final long serialVersionUID = -6701359087661169326L;
+
     /**
      * Result
      */

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/thrift/EntitlementException.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/thrift/EntitlementException.java
@@ -12,6 +12,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class EntitlementException extends Exception implements org.apache.thrift.TBase<EntitlementException, EntitlementException._Fields>, java.io.Serializable, Cloneable {
+
+    private static final long serialVersionUID = 4946371706608936612L;
+
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
         Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);

--- a/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/thrift/EntitlementService.java
+++ b/components/entitlement/org.wso2.carbon.identity.entitlement/src/main/java/org/wso2/carbon/identity/entitlement/thrift/EntitlementService.java
@@ -276,6 +276,9 @@ public class EntitlementService {
     }
 
     public static class getDecision_args implements org.apache.thrift.TBase<getDecision_args, getDecision_args._Fields>, java.io.Serializable, Cloneable {
+
+        private static final long serialVersionUID = 4425435097663962814L;
+
         public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
         static {
             Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/OAuthAppDO.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/OAuthAppDO.java
@@ -21,6 +21,8 @@ import java.io.Serializable;
 
 public class OAuthAppDO implements Serializable {
 
+    private static final long serialVersionUID = -6453843721358989519L;
+
     private int id;
     private String oauthConsumerKey;
     private String oauthConsumerSecret;

--- a/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/SAMLSSOServiceProviderDO.java
+++ b/components/identity-core/org.wso2.carbon.identity.core/src/main/java/org/wso2/carbon/identity/core/model/SAMLSSOServiceProviderDO.java
@@ -29,7 +29,8 @@ import java.util.List;
 
 public class SAMLSSOServiceProviderDO implements Serializable {
 
-    private static final long serialVersionUID = -1213957008659821807L;
+    private static final long serialVersionUID = 7998724745099007704L;
+
     String tenantDomain;
     private String issuer;
     private String assertionConsumerUrl;

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/beans/VerificationBean.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/beans/VerificationBean.java
@@ -27,12 +27,14 @@ import java.io.Serializable;
  */
 public class VerificationBean implements Serializable {
 
+    private static final long serialVersionUID = -2913500119053797062L;
+
     public static final String ERROR_CODE_INVALID_CODE = "18001";
     public static final String ERROR_CODE_EXPIRED_CODE = "18002";
     public static final String ERROR_CODE_INVALID_USER = "18003";
     public static final String ERROR_CODE_INVALID_CAPTCHA = "18004";
     public static final String ERROR_CODE_UNEXPECTED = "18013";
-    private static final long serialVersionUID = -2913500119053797062L;
+
     /**
      * user identifier according to the user store
      */

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/dto/EmailTemplateDTO.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/dto/EmailTemplateDTO.java
@@ -22,10 +22,8 @@ import java.io.Serializable;
 
 public class EmailTemplateDTO implements Serializable {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -8854592668563155088L;
+    private static final long serialVersionUID = -4261083522115621370L;
+
     private String subject;
     private String body;
     private String footer;

--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/dto/UserIdentityClaimsDO.java
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/java/org/wso2/carbon/identity/mgt/dto/UserIdentityClaimsDO.java
@@ -32,12 +32,11 @@ import java.util.Map;
  */
 public class UserIdentityClaimsDO implements Serializable {
 
+    private static final long serialVersionUID = -2450146518801449646L;
+
     public static final int TRUE = 1;
     public static final int FALSE = 2;
-    /**
-     *
-     */
-    private static final long serialVersionUID = -5135352332427377484L;
+
     private String userName;
     private int tenantId;
 

--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/CacheEntry.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/CacheEntry.java
@@ -26,6 +26,6 @@ import java.io.Serializable;
  */
 public abstract class CacheEntry implements Serializable {
 
-    private static final long serialVersionUID = 1574169083965373292L;
+    private static final long serialVersionUID = 1591693579088522864L;
 
 }

--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/CacheKey.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth/cache/CacheKey.java
@@ -27,7 +27,7 @@ import java.io.Serializable;
  */
 public abstract class CacheKey implements Serializable {
 
-    private static final long serialVersionUID = 1471805737633325514L;
+    private static final long serialVersionUID = 5884270521313791351L;
 
     @Override
     public abstract boolean equals(Object otherObject);

--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/OAuth2Parameters.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/OAuth2Parameters.java
@@ -29,7 +29,7 @@ import java.util.Set;
  */
 public class OAuth2Parameters implements Serializable {
 
-    private static final long serialVersionUID = -8719088680725780804L;
+    private static final long serialVersionUID = 2237345658556955974L;
 
     private String applicationName;
     private String redirectURI;

--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/RequestParameter.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/model/RequestParameter.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 public class RequestParameter implements Serializable {
 
     private static final long serialVersionUID = 8094659952209974793L;
+
     private String key;
     private String[] values;
 

--- a/components/openid/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/openid/cache/OpenIDCacheEntry.java
+++ b/components/openid/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/openid/cache/OpenIDCacheEntry.java
@@ -26,6 +26,6 @@ import java.io.Serializable;
  */
 public abstract class OpenIDCacheEntry implements Serializable {
 
-    private static final long serialVersionUID = 1574169083965373292L;
+    private static final long serialVersionUID = -751303874685030226L;
 
 }

--- a/components/openid/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/openid/cache/OpenIDCacheKey.java
+++ b/components/openid/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/openid/cache/OpenIDCacheKey.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
  */
 public abstract class OpenIDCacheKey implements Serializable {
 
-    private static final long serialVersionUID = 1471805737633325514L;
+    private static final long serialVersionUID = -3051944744768628649L;
 
     @Override
     public abstract boolean equals(Object otherObject);

--- a/components/openid/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/openid/replication/AssociationClusterMessage.java
+++ b/components/openid/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/openid/replication/AssociationClusterMessage.java
@@ -28,6 +28,8 @@ import java.io.Serializable;
 
 public class AssociationClusterMessage extends ClusteringMessage implements Serializable {
 
+    private static final long serialVersionUID = 3421028095886637679L;
+
     private static Log log = org.apache.commons.logging.LogFactory.getLog(AssociationClusterMessage.class);
 
     private Association association;

--- a/components/provisioning/org.wso2.carbon.identity.provisioning.connector.google/src/main/java/org/wso2/carbon/identity/provisioning/connector/google/GoogleProvisioningConnectorConfig.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning.connector.google/src/main/java/org/wso2/carbon/identity/provisioning/connector/google/GoogleProvisioningConnectorConfig.java
@@ -32,7 +32,7 @@ import java.util.Properties;
 
 public class GoogleProvisioningConnectorConfig implements Serializable {
 
-    private static final long serialVersionUID = -1198908568546067663L;
+    private static final long serialVersionUID = -3057146255884741487L;
 
     private static final Log log = LogFactory.getLog(GoogleProvisioningConnectorConfig.class);
     private Properties configs;

--- a/components/provisioning/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnectorConfig.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning.connector.salesforce/src/main/java/org/wso2/carbon/identity/provisioning/connector/salesforce/SalesforceProvisioningConnectorConfig.java
@@ -32,7 +32,8 @@ import java.util.Properties;
 
 public class SalesforceProvisioningConnectorConfig implements Serializable {
 
-    private static final long serialVersionUID = 1466757093641438420L;
+    private static final long serialVersionUID = -4476579393653814433L;
+
     private static final Log log = LogFactory.getLog(SalesforceProvisioningConnectorConfig.class);
     private Properties configs;
 

--- a/components/provisioning/org.wso2.carbon.identity.provisioning.connector.spml/src/main/java/org/wso2/carbon/identity/provisioning/connector/spml/SPMLProvisioningConnectorConfig.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning.connector.spml/src/main/java/org/wso2/carbon/identity/provisioning/connector/spml/SPMLProvisioningConnectorConfig.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 public class SPMLProvisioningConnectorConfig implements Serializable {
 
-    private static final long serialVersionUID = -8394278502516014519L;
+    private static final long serialVersionUID = 4084821032056382692L;
 
     private static final Log log = LogFactory.getLog(SPMLProvisioningConnectorConfig.class);
     private Properties configs;

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/AbstractOutboundProvisioningConnector.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/AbstractOutboundProvisioningConnector.java
@@ -33,7 +33,8 @@ import java.util.UUID;
 
 public abstract class AbstractOutboundProvisioningConnector implements Serializable {
 
-    private static final long serialVersionUID = 2196864101772627178L;
+    private static final long serialVersionUID = 8619915839101228583L;
+
     private static final String PROVISIONING_IDP = "IDP";
     private static final String PROVISIONING_TENANT = "TD";
     private static final String PROVISIONING_DOMAIN = "UD";

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisionedIdentifier.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisionedIdentifier.java
@@ -22,10 +22,8 @@ import java.io.Serializable;
 
 public class ProvisionedIdentifier implements Serializable {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -6599321170580333389L;
+
     private String identifier;
 
     /**

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningEntity.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/ProvisioningEntity.java
@@ -26,10 +26,8 @@ import java.util.Map;
 
 public class ProvisioningEntity implements Serializable {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -7300897205165960442L;
+
     private ProvisioningEntityType entityType;
     private ProvisioningOperation operation;
     private ProvisionedIdentifier identifier;

--- a/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/RuntimeProvisioningConfig.java
+++ b/components/provisioning/org.wso2.carbon.identity.provisioning/src/main/java/org/wso2/carbon/identity/provisioning/RuntimeProvisioningConfig.java
@@ -23,10 +23,8 @@ import java.util.Map.Entry;
 
 public class RuntimeProvisioningConfig implements Serializable {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -2629523092537958531L;
+
     private boolean blocking;
     private Entry<String, AbstractOutboundProvisioningConnector> provisioningConnectorEntry;
 

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/CacheEntry.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/CacheEntry.java
@@ -26,5 +26,5 @@ import java.io.Serializable;
  */
 public abstract class CacheEntry implements Serializable {
 
-    private static final long serialVersionUID = 1565107988768069823L;
+    private static final long serialVersionUID = -269579000793589533L;
 }

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/CacheKey.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/cache/CacheKey.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
  */
 public abstract class CacheKey implements Serializable {
 
-    private static final long serialVersionUID = -5992905297718363173L;
+    private static final long serialVersionUID = -7965616737373453027L;
 
     @Override
     public abstract boolean equals(Object otherObject);

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOAuthnReqDTO.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOAuthnReqDTO.java
@@ -25,6 +25,8 @@ import java.util.Map;
 
 public class SAMLSSOAuthnReqDTO implements Serializable {
 
+    private static final long serialVersionUID = -8883458443469019318L;
+
     private AuthenticatedUser user;
     private String password;
     private String issuer;

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOReqValidationResponseDTO.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOReqValidationResponseDTO.java
@@ -23,6 +23,8 @@ import java.io.Serializable;
 
 public class SAMLSSOReqValidationResponseDTO implements Serializable {
 
+    private static final long serialVersionUID = -2483397754723075495L;
+
     private boolean isLogOutReq;
     private boolean isValid;
     private boolean doSingleLogout;

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSORespDTO.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSORespDTO.java
@@ -23,6 +23,8 @@ import java.io.Serializable;
 
 public class SAMLSSORespDTO implements Serializable {
 
+    private static final long serialVersionUID = 5848839581755256822L;
+
     private String respString;
     private boolean isSessionEstablished;
     private String assertionConsumerURL;

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderDTO.java
@@ -25,6 +25,8 @@ import java.io.Serializable;
 
 public class SAMLSSOServiceProviderDTO implements Serializable {
 
+    private static final long serialVersionUID = -7633935958583257097L;
+
     private String issuer;
     private String[] assertionConsumerUrls;
     private String defaultAssertionConsumerUrl;

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderInfoDTO.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOServiceProviderInfoDTO.java
@@ -25,6 +25,8 @@ import java.io.Serializable;
  */
 public class SAMLSSOServiceProviderInfoDTO implements Serializable {
 
+    private static final long serialVersionUID = 734702495756927187L;
+
     private SAMLSSOServiceProviderDTO[] serviceProviders;
     private String pubCertFilePath;
     private boolean isTenantZero;

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOSessionDTO.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SAMLSSOSessionDTO.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
 
 public class SAMLSSOSessionDTO implements Serializable {
 
-    private static final long serialVersionUID = 3806660562465698477L;
+    private static final long serialVersionUID = -412560012894923237L;
 
     private String httpQueryString;
     private String destination;

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SingleLogoutRequestDTO.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/dto/SingleLogoutRequestDTO.java
@@ -21,6 +21,8 @@ import java.io.Serializable;
 
 public class SingleLogoutRequestDTO implements Serializable {
 
+    private static final long serialVersionUID = -5086237688925774301L;
+
     private String assertionConsumerURL;
     private String logoutResponse;
     private String rpSessionId;

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/session/SessionInfoData.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/session/SessionInfoData.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class SessionInfoData implements Serializable {
 
-    private static final long serialVersionUID = -2997545986276529377L;
+    private static final long serialVersionUID = -7219077849244588172L;
 
     private Map<String, String> rpSessionList = new ConcurrentHashMap<>();
     private Map<String, SAMLSSOServiceProviderDO> serviceProviderList = new ConcurrentHashMap<>();

--- a/components/sts/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/cache/CacheEntry.java
+++ b/components/sts/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/cache/CacheEntry.java
@@ -26,5 +26,5 @@ import java.io.Serializable;
  */
 public abstract class CacheEntry implements Serializable {
 
-    private static final long serialVersionUID = 1565107988768069823L;
+    private static final long serialVersionUID = -6881822564580955137L;
 }

--- a/components/sts/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/cache/CacheKey.java
+++ b/components/sts/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/cache/CacheKey.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
  */
 public abstract class CacheKey implements Serializable {
 
-    private static final long serialVersionUID = -5992905297718363173L;
+    private static final long serialVersionUID = -3956022845664741377L;
 
     @Override
     public abstract boolean equals(Object otherObject);

--- a/components/sts/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/dto/SessionDTO.java
+++ b/components/sts/org.wso2.carbon.identity.sts.passive.ui/src/main/java/org/wso2/carbon/identity/sts/passive/ui/dto/SessionDTO.java
@@ -21,10 +21,9 @@ package org.wso2.carbon.identity.sts.passive.ui.dto;
 import java.io.Serializable;
 
 public class SessionDTO implements Serializable {
-    /**
-     *
-     */
-    private static final long serialVersionUID = -7913481758803777374L;
+
+    private static final long serialVersionUID = -8474813773329096446L;
+
     //wa
     private String action;
     //wattr

--- a/components/sts/org.wso2.carbon.identity.sts.store/src/main/java/org/wso2/carbon/identity/sts/store/SerializableToken.java
+++ b/components/sts/org.wso2.carbon.identity.sts.store/src/main/java/org/wso2/carbon/identity/sts/store/SerializableToken.java
@@ -28,6 +28,8 @@ import java.util.Properties;
  */
 public class SerializableToken implements Serializable {
 
+    private static final long serialVersionUID = 1101734842629522246L;
+
     private String id;
     private int state;
     private String token;

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/beans/RandomPassword.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/beans/RandomPassword.java
@@ -26,6 +26,8 @@ import java.io.Serializable;
 public class RandomPassword implements Serializable {
 
 
+    private static final long serialVersionUID = -7465588466247931040L;
+
     private String propertyName;
 
     //private String password;

--- a/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/beans/RandomPasswordContainer.java
+++ b/components/user-store/org.wso2.carbon.identity.user.store.configuration/src/main/java/org/wso2/carbon/identity/user/store/configuration/beans/RandomPasswordContainer.java
@@ -26,6 +26,8 @@ import java.io.Serializable;
  */
 public class RandomPasswordContainer implements Serializable {
 
+    private static final long serialVersionUID = -5282260905622533906L;
+
     private RandomPassword[] randomPasswords;
     private String uniqueID;
 

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/bean/Parameter.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/bean/Parameter.java
@@ -33,6 +33,8 @@ import java.io.Serializable;
  */
 public class Parameter implements Serializable {
 
+    private static final long serialVersionUID = 7063803305644510640L;
+
     private String workflowId;
     private String paramName;
     private String paramValue;

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/bean/RequestParameter.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/bean/RequestParameter.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 
 public class RequestParameter implements Serializable{
 
+    private static final long serialVersionUID = -8564170214424881696L;
+
     private String name;
     private Object value;
     private String valueType;

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/bean/Workflow.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/bean/Workflow.java
@@ -25,6 +25,8 @@ import java.io.Serializable;
  */
 public class Workflow implements Serializable {
 
+    private static final long serialVersionUID = -5191252401224311955L;
+
     private String workflowId;
     private String workflowName;
     private String workflowDescription;

--- a/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dto/WorkflowRequest.java
+++ b/components/workflow-mgt/org.wso2.carbon.identity.workflow.mgt/src/main/java/org/wso2/carbon/identity/workflow/mgt/dto/WorkflowRequest.java
@@ -24,12 +24,15 @@ import java.io.Serializable;
 import java.util.List;
 
 public class WorkflowRequest implements Serializable, Cloneable {
+
+    private static final long serialVersionUID = 578401681187017212L;
+
     public static final String CREDENTIAL = "Credential";
     private String uuid;
     private String eventType;
     private int tenantId;
     private List<RequestParameter> requestParameters;
-    private static final long serialVersionUID = -684287450983377460L;
+
 
     public String getUuid() {
         return uuid;


### PR DESCRIPTION
Adding serialVersionUID if the class is serializable and no serialVersionUID field exists, or updating its value if it's different from the one the 'serialver' tool would return