### PR TITLE
Fixing the unexpected format violated exception, when fetching OAuth tokens 

### DIFF
--- a/components/oauth/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth.endpoint/src/main/java/org/wso2/carbon/identity/oauth/endpoint/util/EndpointUtil.java
@@ -142,7 +142,7 @@ public class EndpointUtil {
     public static String[] extractCredentialsFromAuthzHeader(String authorizationHeader)
             throws OAuthClientException {
         String[] splitValues = authorizationHeader.trim().split(" ");
-        if(splitValues.length == 2) {
+        if(splitValues.length >= 2) {
             byte[] decodedBytes = Base64Utils.decode(splitValues[1].trim());
             if (decodedBytes != null) {
                 String userNamePassword = new String(decodedBytes, Charsets.UTF_8);


### PR DESCRIPTION
Line 145 change form if(splitValues.length == 2) { to if(splitValues.length >= 2) {

this fix enables fetching OAuth tokens using curl with out any issues.
In the validation it must let the flow process ahead with out any blocks if the index 1 is available.
Before it block when the index 1 is available with more than 2 indexes in the array.