### PR TITLE
Fixing IDENTITY-3699

### DIFF
--- a/components/agents/org.wso2.carbon.identity.sso.agent/src/main/java/org/wso2/carbon/identity/sso/agent/SSOAgentRequestResolver.java
+++ b/components/agents/org.wso2.carbon.identity.sso.agent/src/main/java/org/wso2/carbon/identity/sso/agent/SSOAgentRequestResolver.java
@@ -43,7 +43,7 @@ public class SSOAgentRequestResolver {
     public boolean isSLORequest() {
 
         return ssoAgentConfig.isSAML2SSOLoginEnabled() &&
-                request.getParameter(AuthnRequest.DEFAULT_ELEMENT_LOCAL_NAME) != null;
+                request.getParameter(SSOAgentConstants.SAML2SSO.HTTP_POST_PARAM_SAML2_AUTH_REQ) != null;
     }
 
     // This could be either SAML Response for a SSO SAML Request by the client application

--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultLogoutRequestHandler.java
@@ -126,6 +126,23 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
                     log.error("Exception while getting IdP by name", e);
                 }
             }
+
+            String auditData = "\"" + "ContextIdentifier" + "\" : \"" + context.getContextIdentifier()
+                    + "\",\"" + "LoggedOutUser" + "\" : \"" + sequenceConfig.getAuthenticatedUser().
+                    getAuthenticatedSubjectIdentifier()
+                    + "\",\"" + "LoggedOutUserTenantDomain" + "\" : \"" + sequenceConfig.
+                    getAuthenticatedUser().getTenantDomain()
+                    + "\",\"" + "ServiceProviderName" + "\" : \"" + context.getServiceProviderName()
+                    + "\",\"" + "RequestType" + "\" : \"" + context.getRequestType()
+                    + "\",\"" + "RelyingParty" + "\" : \"" + context.getRelyingParty()
+                    + "\",\"" + "AuthenticatedIdPs" + "\" : \"" + sequenceConfig.getAuthenticatedIdPs()
+                    + "\"";
+
+            AUDIT_LOG.info(String.format(
+                    FrameworkConstants.AUDIT_MESSAGE,
+                    sequenceConfig.getAuthenticatedUser().getAuthenticatedSubjectIdentifier(),
+                    "Logout",
+                    externalIdPConfig.getIdPName(), auditData, FrameworkConstants.AUDIT_SUCCESS));
         }
 
         // remove the SessionContext from the cache
@@ -134,22 +151,6 @@ public class DefaultLogoutRequestHandler implements LogoutRequestHandler {
         FrameworkUtils.removeAuthCookie(request, response);
 
 
-        String auditData = "\"" + "ContextIdentifier" + "\" : \"" + context.getContextIdentifier()
-                + "\",\"" + "LoggedOutUser" + "\" : \"" + sequenceConfig.getAuthenticatedUser().
-                getAuthenticatedSubjectIdentifier()
-                + "\",\"" + "LoggedOutUserTenantDomain" + "\" : \"" + sequenceConfig.
-                getAuthenticatedUser().getTenantDomain()
-                + "\",\"" + "ServiceProviderName" + "\" : \"" + context.getServiceProviderName()
-                + "\",\"" + "RequestType" + "\" : \"" + context.getRequestType()
-                + "\",\"" + "RelyingParty" + "\" : \"" + context.getRelyingParty()
-                + "\",\"" + "AuthenticatedIdPs" + "\" : \"" + sequenceConfig.getAuthenticatedIdPs()
-                + "\"";
-
-        AUDIT_LOG.info(String.format(
-                FrameworkConstants.AUDIT_MESSAGE,
-                sequenceConfig.getAuthenticatedUser().getAuthenticatedSubjectIdentifier(),
-                "Logout",
-                externalIdPConfig.getIdPName(), auditData, FrameworkConstants.AUDIT_SUCCESS));
 
         try {
             sendResponse(request, response, context, true);


### PR DESCRIPTION
The reported behavior occurred due to a issue in the sample. Fixed that in https://github.com/darshanasbg/carbon-identity/commit/78959e7ec8bf911c25805d4fe90dfaa4fc159463

And the other issue was, the authentication framework throwing a NPEs when sending incorrect logout meessages. For example if a user darshana@foo.com is already loogged in and he try to logout by sending a logout messsage without providing the tenant domain correctly, it will use default super tenant domain to invalidate the session. While printing the audit logs its try to retrieve logged in user's info which cause for a NPE due to tenant mismatch. That NPE is avoided with https://github.com/darshanasbg/carbon-identity/commit/f92934d29a742d5eecbf12692d5c3898f96f55c6