### PR TITLE
Fixing IDENTITY-3816

### DIFF
--- a/components/application-authenticators/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticator.java
+++ b/components/application-authenticators/org.wso2.carbon.identity.application.authenticator.iwa/src/main/java/org/wso2/carbon/identity/application/authenticator/iwa/IWAAuthenticator.java
@@ -57,8 +57,8 @@ public class IWAAuthenticator extends AbstractApplicationAuthenticator implement
     public boolean canHandle(HttpServletRequest request) {
         //check whether the OS is windows. IWA works only with windows
         String osName = System.getProperty(IWAConstants.OS_NAME_PROPERTY);
-        return StringUtils.isNotEmpty(osName) && osName.contains(IWAConstants.WINDOWS_OS_MATCH_STRING) && request
-                .getParameter(IWA_PROCESSED) != null;
+        return StringUtils.isNotEmpty(osName) && osName.toLowerCase().contains(IWAConstants.WINDOWS_OS_MATCH_STRING) &&
+                request.getParameter(IWA_PROCESSED) != null;
     }
 
     @Override


### PR DESCRIPTION
When debugging, it's seen that to pick iwa authenticator its looking for OS,
* which contains (lower case) string :  "win" in its "os.name" system property
* while some operating systems returning values like "Windows Server 2008"

which lead to canHandle() false.