### PR TITLE
Removing ununsed service from services.xml and making UserIdentityManagementAdminService hidden

### DIFF
--- a/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/resources/META-INF/services.xml
+++ b/components/identity-mgt/org.wso2.carbon.identity.mgt/src/main/resources/META-INF/services.xml
@@ -30,18 +30,6 @@
 		<parameter name="AuthorizationAction" locked="true">/permission/admin/login</parameter>
 	</service>
 
-	<service name="AccountCredentialMgtConfigService" scope="transportsession">
-		<transports>
-			<transport>https</transport>
-		</transports>
-		<parameter name="ServiceClass" locked="false">
-			org.wso2.carbon.identity.mgt.services.AccountCredentialMgtConfigService
-		</parameter>
-		<parameter name="adminService" locked="true">true</parameter>
-		<parameter name="hiddenService" locked="false">false</parameter>
-		<parameter name="AuthorizationAction" locked="true">/permission/admin/login</parameter>
-	</service>
-
     <service name="UserIdentityManagementAdminService" scope="transportsession">
         <transports>
             <transport>https</transport>
@@ -92,7 +80,7 @@
             <parameter name="AuthorizationAction" locked="true">/permission/admin/configure/security</parameter>
         </operation>
         <parameter name="adminService" locked="false">true</parameter>
-        <parameter name="hiddenService" locked="false">false</parameter>
+        <parameter name="hiddenService" locked="false">true</parameter>
         <parameter name="AuthorizationAction" locked="false">/permission/admin/configure/security</parameter>
    </service>
 


### PR DESCRIPTION
Removing unused service from services.xml and making UserIdentityManagementAdminService hidden service because, one its an admin service and secondly an unwated log is being printed at server startup saying it is deployed successfully