### PR TITLE
Fixing the issue "org.apache.axis2.databinding.ADBException" in IDP update.

### DIFF
--- a/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
+++ b/service-stubs/identity/org.wso2.carbon.idp.mgt.stub/src/main/resources/IdentityProviderMgtService.wsdl
@@ -92,6 +92,7 @@
             </xs:complexType>
             <xs:complexType name="InboundProvisioningConfig">
                 <xs:sequence>
+                    <xs:element minOccurs="0" name="dumbMode" type="xs:boolean"/>
                     <xs:element minOccurs="0" name="provisioningEnabled" type="xs:boolean"></xs:element>
                     <xs:element minOccurs="0" name="provisioningUserStore" nillable="true" type="xs:string"></xs:element>
                 </xs:sequence>


### PR DESCRIPTION
Fixing the issue "org.apache.axis2.databinding.ADBException: Unexpected subelement {http://model.common.application.identity.carbon.wso2.org/xsd}dumbMode" while updating the idp configurations.