### PR TITLE
fix issue where tenant domain is added twice to the authorized username

### DIFF
--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -290,7 +291,7 @@ public class TokenValidationHandler {
 
         User user = accessTokenDO.getAuthzUser();
         String authzUser = UserCoreUtil.addDomainToName(user.getUserName(), user.getUserStoreDomain());
-        authzUser = UserCoreUtil.addTenantDomainToEntry(authzUser, user.getTenantDomain());
+        //authzUser = UserCoreUtil.addTenantDomainToEntry(authzUser, user.getTenantDomain());
         responseDTO.setAuthorizedUser(authzUser);
         responseDTO.setScope(accessTokenDO.getScope());
         responseDTO.setValid(true);

--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java
@@ -36,8 +36,6 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
-import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
-
 import java.util.HashMap;
 import java.util.Map;
 


### PR DESCRIPTION
when oauth2 token is generated, authorized user name is saved with the tenant domain in IDN_OAUTH2_ACCESS_TOKEN table. findOAuthConsumerIfTokenIsValid() adds the tenant domain again to the user name.
related issue in API manager https://wso2.org/jira/browse/APIMANAGER-4197. (see enduser)