### PR TITLE
fixing IDENTITY-4107

### DIFF
--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -490,7 +490,7 @@ public class OAuth2Util {
     }
 
     public static String hashScopes(String scope){
-        if (StringUtils.isNotBlank(scope)) {
+        if (scope != null) {
             //first converted to an array to sort the scopes
             return DigestUtils.md5Hex(OAuth2Util.buildScopeString(buildScopeArray(scope)));
         } else {


### PR DESCRIPTION
If an empty string comes (when there is no scope an empty string comes), it should also be hashed and stored.