### PR TITLE
Improving fix for clearing ThreadLocalProvisioningServiceProvider

### DIFF
--- a/components/scim/org.wso2.carbon.identity.scim.provider/src/main/java/org/wso2/carbon/identity/scim/provider/filter/AuthenticationFilter.java
+++ b/components/scim/org.wso2.carbon.identity.scim.provider/src/main/java/org/wso2/carbon/identity/scim/provider/filter/AuthenticationFilter.java
@@ -67,6 +67,7 @@ public class AuthenticationFilter implements RequestHandler, ResponseHandler {
                 AbstractResourceEndpoint.encodeSCIMException(new JSONEncoder(), unauthorizedException));
     }
 
+    // To clear the ThreadLocalProvisioningServiceProvider in a non faulty case
     @Override
     public Response handleResponse(Message message, OperationResourceInfo operationResourceInfo, Response response) {
         IdentityApplicationManagementUtil.resetThreadLocalProvisioningServiceProvider();

--- a/components/scim/org.wso2.carbon.identity.scim.provider/src/main/java/org/wso2/carbon/identity/scim/provider/util/ClearThreadLocalInterceptor.java
+++ b/components/scim/org.wso2.carbon.identity.scim.provider/src/main/java/org/wso2/carbon/identity/scim/provider/util/ClearThreadLocalInterceptor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.scim.provider.util;
+
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.Phase;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
+
+/**
+ * To clear the ThreadLocalProvisioningServiceProvider in a faulty case
+ */
+public class ClearThreadLocalInterceptor extends AbstractPhaseInterceptor<Message> {
+
+    public ClearThreadLocalInterceptor() {
+        super(Phase.PRE_INVOKE);
+    }
+
+    public void handleMessage(Message message) {
+        // nothing to implement
+        return;
+    }
+
+    public void handleFault(Message message) {
+        IdentityApplicationManagementUtil.resetThreadLocalProvisioningServiceProvider();
+    }
+}

--- a/components/scim/org.wso2.carbon.identity.scim.provider/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/components/scim/org.wso2.carbon.identity.scim.provider/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -19,10 +19,11 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:jaxrs="http://cxf.apache.org/jaxrs"
+       xmlns:jaxrs="http://cxf.apache.org/jaxrs" xmlns:cxf="http://cxf.apache.org/core"
        xsi:schemaLocation="
          http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-         http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd">
+         http://cxf.apache.org/jaxrs http://cxf.apache.org/schemas/jaxrs.xsd
+         http://cxf.apache.org/core http://cxf.apache.org/schemas/core.xsd">
 
     <jaxrs:server id="userResource" address="/Users">
         <jaxrs:serviceBeans>
@@ -65,5 +66,14 @@
     <bean id="authenticationFilter" class="org.wso2.carbon.identity.scim.provider.filter.AuthenticationFilter">
             <!-- authorization bean properties -->
         </bean>
+
+    <bean id="ClearThreadLocalInterceptor" class="org.wso2.carbon.identity.scim.provider.util.ClearThreadLocalInterceptor"/>
+
+    <cxf:bus>
+        <cxf:inInterceptors>
+            <ref bean="ClearThreadLocalInterceptor"/>
+        </cxf:inInterceptors>
+    </cxf:bus>
+
 </beans>
 


### PR DESCRIPTION
Improving fix for clearing ThreadLocalProvisioningServiceProvider if a RuntimeException occurs