### PR TITLE
Commenting out <IDTokenIssuerID> element as we are not filling the te…

### DIFF
--- a/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
+++ b/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml
@@ -245,7 +245,7 @@
                 Default value for IDTokenIssuerID, is OAuth2TokenEPUrl.
                 If that doesn't satisfy uncomment the following config and explicitly configure the value
             -->
-            <IDTokenIssuerID>${carbon.protocol}://${carbon.host}:${mgt.transport.https.port}/oauth2/token</IDTokenIssuerID>
+            <!--IDTokenIssuerID>${carbon.protocol}://${carbon.host}:${mgt.transport.https.port}/oauth2/token</IDTokenIssuerID-->
             <IDTokenSubjectClaim>http://wso2.org/claims/givenname</IDTokenSubjectClaim>
             <IDTokenCustomClaimsCallBackHandler>org.wso2.carbon.identity.openidconnect.SAMLAssertionClaimsCallback</IDTokenCustomClaimsCallBackHandler>
             <IDTokenExpiration>3600</IDTokenExpiration>


### PR DESCRIPTION
…mplate values in code and this miss leads to a token's iss value as below, ""iss":"${carbon.protocol}:\/\/${carbon.host}:${mgt.transport.https.port}\/oauth2\/token""