### PR TITLE
Setting Secure Flag for Cookies

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/tenantauth.jsp
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.endpoint/src/main/webapp/tenantauth.jsp
@@ -115,7 +115,7 @@
             var date = new Date();
             date.setTime(date.getTime() + (exdays * 24 * 60 * 60 * 1000));
             var expires = "expires=" + date.toUTCString();
-            document.cookie = "selectedTenantDomain=" + cvalue + "; " + expires + "; secure; HttpOnly";
+            document.cookie = "selectedTenantDomain=" + cvalue + "; " + expires + "; secure";
         }
 
         /**


### PR DESCRIPTION
removed HttpOnly flag since it's not applicable within javascript