### PR TITLE
admin can't see any SP in web admin console

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -148,7 +148,7 @@ public class ApplicationMgtUtil {
     }
 
     private static String getAppRoleName(String applicationName) {
-        return ApplicationConstants.APPLICATION_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + applicationName;
+        return UserCoreConstants.INTERNAL_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + applicationName;
     }
 
     /**

--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/SAMLAssertionClaimsCallback.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/SAMLAssertionClaimsCallback.java
@@ -112,6 +112,9 @@ public class SAMLAssertionClaimsCallback implements CustomClaimsCallbackHandler 
                 }
 
                 for (Map.Entry<String, Object> entry : claims.entrySet()) {
+                    if (jwtClaimsSet.getClaim(entry.getKey()) != null) {
+                        continue;
+                    }
                     String value = entry.getValue().toString();
                     values = new JSONArray();
                     if (userAttributeSeparator != null && value.contains(userAttributeSeparator)) {

--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/SAMLAssertionClaimsCallback.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/SAMLAssertionClaimsCallback.java
@@ -112,9 +112,6 @@ public class SAMLAssertionClaimsCallback implements CustomClaimsCallbackHandler 
                 }
 
                 for (Map.Entry<String, Object> entry : claims.entrySet()) {
-                    if (jwtClaimsSet.getClaim(entry.getKey()) != null) {
-                        continue;
-                    }
                     String value = entry.getValue().toString();
                     values = new JSONArray();
                     if (userAttributeSeparator != null && value.contains(userAttributeSeparator)) {


### PR DESCRIPTION
We use custom UserStoreManager based on JDBCUserStoreManager
After upgrade to v5.1 admin can't see any SPs in admin console.
We assume it is because AbstractUserStoreManager.doGetInternalRoleListOfUser calls hybridRoleManager.getHybridRoleListOfUser and it adds 'Internal' domain to all roles retrieved from DB.
At the same time when it does role verification (in admin console) it calls ApplicationMgtUtil which expects roles with domain 'Application'

We apply this patch and SPs become visible for admin
Maybe it shall be corrected some elsewhere or we use completely wrong approach 