### PR TITLE
Admin can't see any SP in web admin console

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -148,7 +148,7 @@ public class ApplicationMgtUtil {
     }
 
     private static String getAppRoleName(String applicationName) {
-        return ApplicationConstants.APPLICATION_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + applicationName;
+        return UserCoreConstants.INTERNAL_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + applicationName;
     }
 
     /**


### PR DESCRIPTION
We use custom UserStoreManager based on JDBCUserStoreManager
After upgrade to v5.1 admin can't see any SPs in admin console.
We assume it is because AbstractUserStoreManager.doGetInternalRoleListOfUser calls hybridRoleManager.getHybridRoleListOfUser and it adds 'Internal' domain to all roles retrieved from DB.
At the same time when it does role verification (in admin console) it calls ApplicationMgtUtil which expects roles with domain 'Application'

We apply this patch and SPs become visible for admin
Maybe it shall be corrected some elsewhere or we use completely wrong approach
