### PR TITLE
Id-token contains sub as array instead of string

### DIFF
--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -148,7 +148,7 @@ public class ApplicationMgtUtil {
     }
 
     private static String getAppRoleName(String applicationName) {
-        return ApplicationConstants.APPLICATION_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + applicationName;
+        return UserCoreConstants.INTERNAL_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + applicationName;
     }
 
     /**

--- a/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
+++ b/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationMgtUtil.java
@@ -148,7 +148,7 @@ public class ApplicationMgtUtil {
     }
 
     private static String getAppRoleName(String applicationName) {
-        return UserCoreConstants.INTERNAL_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + applicationName;
+        return ApplicationConstants.APPLICATION_DOMAIN + UserCoreConstants.DOMAIN_SEPARATOR + applicationName;
     }
 
     /**

--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/SAMLAssertionClaimsCallback.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/SAMLAssertionClaimsCallback.java
@@ -112,6 +112,9 @@ public class SAMLAssertionClaimsCallback implements CustomClaimsCallbackHandler 
                 }
 
                 for (Map.Entry<String, Object> entry : claims.entrySet()) {
+                    if (jwtClaimsSet.getClaim(entry.getKey()) != null) {
+                        continue;
+                    }
                     String value = entry.getValue().toString();
                     values = new JSONArray();
                     if (userAttributeSeparator != null && value.contains(userAttributeSeparator)) {

--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/SAMLAssertionClaimsCallback.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/openidconnect/SAMLAssertionClaimsCallback.java
@@ -112,9 +112,6 @@ public class SAMLAssertionClaimsCallback implements CustomClaimsCallbackHandler 
                 }
 
                 for (Map.Entry<String, Object> entry : claims.entrySet()) {
-                    if (jwtClaimsSet.getClaim(entry.getKey()) != null) {
-                        continue;
-                    }
                     String value = entry.getValue().toString();
                     values = new JSONArray();
                     if (userAttributeSeparator != null && value.contains(userAttributeSeparator)) {


### PR DESCRIPTION
After migration 5.0sp1 -> 5.1 we've faced with following issue:
when user is getting from cache its login-id appends as a sub claim by SAMLAssertionClaimsCallback. As a result SP receives id-token with following claim: {...sub: ["XXX"], ... }instead of {... sub: "XXX", ...}.
So we add a condition to prevent claim overriding.