### PR TITLE
Direct nano timestamp for the session time_created field

### DIFF
--- a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
+++ b/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/store/SessionDataStore.java
@@ -365,10 +365,6 @@ public class SessionDataStore {
 
         // create a nano time stamp relative to Unix Epoch
         long currentStandardNano = timestamp.getTime() * 1000000;
-        long currentSystemNano = System.nanoTime();
-
-        currentStandardNano = currentStandardNano + (currentSystemNano - FrameworkServiceDataHolder.getInstance()
-                .getNanoTimeReference());
 
         try {
             preparedStatement = connection.prepareStatement(sqlInsertSTORE);


### PR DESCRIPTION
The time_created value of the session storage was moved to the future by the server uptime value. Is there reason for that? Companies usually require (and test) session timeouts, this was it is possible to control them.
