### PR TITLE
AccessToken expires earlier than validity period exceeds

### DIFF
--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/token/handlers/grant/RefreshGrantHandler.java
@@ -157,7 +157,7 @@ public class RefreshGrantHandler extends AbstractAuthorizationGrantHandler {
 	long refreshValidity = refreshTokenValidationDataDO.getValidityPeriodInMillis();
 	long skew = OAuthServerConfiguration.getInstance().getTimeStampSkewInSeconds() * 1000;
 
-	if (issuedTime + refreshValidity - (System.currentTimeMillis() + skew) > 1000) {
+	if (issuedTime + refreshValidity - (System.currentTimeMillis() - skew) > 1000) {
 	    if (!renew) {
 		// if refresh token renewal not enabled, we use existing one else we issue a new refresh token
 		refreshToken = oauth2AccessTokenReqDTO.getRefreshToken();

--- a/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
+++ b/components/oauth/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/util/OAuth2Util.java
@@ -407,13 +407,13 @@ public class OAuth2Util {
 
         //check the validity of cached OAuth2AccessToken Response
         long skew = OAuthServerConfiguration.getInstance().getTimeStampSkewInSeconds() * 1000;
-        if (issuedTime + validityPeriodMillis - (currentTime + skew) > 1000) {
+        if (issuedTime + validityPeriodMillis - (currentTime - skew) > 1000) {
             long refreshValidity = OAuthServerConfiguration.getInstance()
                     .getRefreshTokenValidityPeriodInSeconds() * 1000;
             if (issuedTime + refreshValidity - currentTime + skew > 1000) {
                 //Set new validity period to response object
-                accessTokenDO.setValidityPeriod((issuedTime + validityPeriodMillis - (currentTime + skew)) / 1000);
-                accessTokenDO.setValidityPeriodInMillis(issuedTime + validityPeriodMillis - (currentTime + skew));
+                accessTokenDO.setValidityPeriod((issuedTime + validityPeriodMillis - currentTime) / 1000);
+                accessTokenDO.setValidityPeriodInMillis(issuedTime + validityPeriodMillis - currentTime);
                 //Set issued time period to response object
                 accessTokenDO.setIssuedTime(new Timestamp(currentTime));
                 return accessTokenDO;
@@ -538,9 +538,9 @@ public class OAuth2Util {
         long issuedTime = accessTokenDO.getIssuedTime().getTime();
         currentTime = System.currentTimeMillis();
         long refreshTokenIssuedTime = accessTokenDO.getRefreshTokenIssuedTime().getTime();
-        long accessTokenValidity = issuedTime + validityPeriodMillis - (currentTime + timestampSkew);
+        long accessTokenValidity = issuedTime + validityPeriodMillis - (currentTime - timestampSkew);
         long refreshTokenValidity = (refreshTokenIssuedTime + refreshTokenValidityPeriodMillis)
-                                    - (currentTime + timestampSkew);
+                                    - (currentTime - timestampSkew);
         if(accessTokenValidity > 1000 && refreshTokenValidity > 1000){
             return accessTokenValidity;
         }
@@ -564,7 +564,7 @@ public class OAuth2Util {
         currentTime = System.currentTimeMillis();
         long refreshTokenIssuedTime = accessTokenDO.getRefreshTokenIssuedTime().getTime();
         long refreshTokenValidity = (refreshTokenIssuedTime + refreshTokenValidityPeriodMillis)
-                                    - (currentTime + timestampSkew);
+                                    - (currentTime - timestampSkew);
         if(refreshTokenValidity > 1000){
             return refreshTokenValidity;
         }
@@ -586,7 +586,7 @@ public class OAuth2Util {
 
         long issuedTime = accessTokenDO.getIssuedTime().getTime();
         currentTime = System.currentTimeMillis();
-        long validityMillis = issuedTime + validityPeriodMillis - (currentTime + timestampSkew);
+        long validityMillis = issuedTime + validityPeriodMillis - (currentTime - timestampSkew);
         if (validityMillis > 1000) {
             return validityMillis;
         } else {


### PR DESCRIPTION
We have faced with situations when accessToken expires but the validity period does not exceed (5 or less minutes left).
Clocks are in good sync between hosts.
Skew Timeout is default 5 minutes.
It seems that the logic of skew timeouts has arithmetic issues.
These changes are gonna fix it.
