### PR TITLE
Adjusting the validation problem 'Assertion.NotBefore'

### DIFF
--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/DefaultResponseBuilder.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/DefaultResponseBuilder.java
@@ -65,7 +65,7 @@ public class DefaultResponseBuilder implements ResponseBuilder {
         DateTime notOnOrAfter = new DateTime(issueInstant.getMillis()
                 + SAMLSSOUtil.getSAMLResponseValidityPeriod() * 60 * 1000L);
         response.setIssueInstant(issueInstant);
-        Assertion assertion = SAMLSSOUtil.buildSAMLAssertion(authReqDTO, notOnOrAfter, sessionId);
+        Assertion assertion = SAMLSSOUtil.buildSAMLAssertion(authReqDTO, issueInstant, notOnOrAfter, sessionId);
 
         if (authReqDTO.isDoEnableEncryptedAssertion()) {
 

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/DefaultSAMLAssertionBuilder.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/DefaultSAMLAssertionBuilder.java
@@ -76,14 +76,14 @@ public class DefaultSAMLAssertionBuilder implements SAMLAssertionBuilder {
     }
 
     @Override
-    public Assertion buildAssertion(SAMLSSOAuthnReqDTO authReqDTO, DateTime notOnOrAfter, String sessionId) throws IdentityException {
+    public Assertion buildAssertion(SAMLSSOAuthnReqDTO authReqDTO, DateTime issueInstant, DateTime notOnOrAfter, String sessionId) throws IdentityException {
         try {
-            DateTime currentTime = new DateTime();
+            
             Assertion samlAssertion = new AssertionBuilder().buildObject();
             samlAssertion.setID(SAMLSSOUtil.createID());
             samlAssertion.setVersion(SAMLVersion.VERSION_20);
             samlAssertion.setIssuer(SAMLSSOUtil.getIssuer());
-            samlAssertion.setIssueInstant(currentTime);
+            samlAssertion.setIssueInstant(issueInstant);
             Subject subject = new SubjectBuilder().buildObject();
 
             NameID nameId = new NameIDBuilder().buildObject();
@@ -165,7 +165,7 @@ public class DefaultSAMLAssertionBuilder implements SAMLAssertionBuilder {
                 }
             }
             Conditions conditions = new ConditionsBuilder().buildObject();
-            conditions.setNotBefore(currentTime);
+            conditions.setNotBefore(issueInstant);
             conditions.setNotOnOrAfter(notOnOrAfter);
             conditions.getAudienceRestrictions().add(audienceRestriction);
             samlAssertion.setConditions(conditions);

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/SAMLAssertionBuilder.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/builders/assertion/SAMLAssertionBuilder.java
@@ -30,13 +30,14 @@ public interface SAMLAssertionBuilder {
      * Encrypt the SAML assertion
      *
      * @param authReqDTO   SAML assertion to be encrypted
-     * @param notOnOrAfter Encrypting credential
+     * @param issueInstant Issue Instan date
+     * @param notOnOrAfter NotOnOrAfter assertion date
      * @param sessionId    Certificate alias against which use to Encrypt the assertion.
      * @return Assertion
      * @throws IdentityException
      */
 
-    public Assertion buildAssertion(SAMLSSOAuthnReqDTO authReqDTO, DateTime notOnOrAfter,
+    public Assertion buildAssertion(SAMLSSOAuthnReqDTO authReqDTO, DateTime issueInstant, DateTime notOnOrAfter,
                                     String sessionId) throws IdentityException;
 
 }

--- a/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
+++ b/components/sso-saml/org.wso2.carbon.identity.sso.saml/src/main/java/org/wso2/carbon/identity/sso/saml/util/SAMLSSOUtil.java
@@ -677,7 +677,7 @@ public class SAMLSSOUtil {
         }
     }
 
-    public static Assertion buildSAMLAssertion(SAMLSSOAuthnReqDTO authReqDTO, DateTime notOnOrAfter,
+    public static Assertion buildSAMLAssertion(SAMLSSOAuthnReqDTO authReqDTO, DateTime issueInstant, DateTime notOnOrAfter,
                                                String sessionId) throws IdentityException {
 
         doBootstrap();
@@ -700,7 +700,7 @@ public class SAMLSSOUtil {
                 samlAssertionBuilder = (SAMLAssertionBuilder) Class.forName(assertionBuilderClass).newInstance();
                 samlAssertionBuilder.init();
             }
-            return samlAssertionBuilder.buildAssertion(authReqDTO, notOnOrAfter, sessionId);
+            return samlAssertionBuilder.buildAssertion(authReqDTO, issueInstant, notOnOrAfter, sessionId);
 
         } catch (ClassNotFoundException e) {
             throw IdentityException.error("Class not found: "

--- a/components/tools/samlsso-validator/org.wso2.carbon.identity.tools.saml.validator/src/main/java/org/wso2/carbon/identity/tools/saml/validator/processors/SAMLResponseBuilder.java
+++ b/components/tools/samlsso-validator/org.wso2.carbon.identity.tools.saml.validator/src/main/java/org/wso2/carbon/identity/tools/saml/validator/processors/SAMLResponseBuilder.java
@@ -101,7 +101,7 @@ public class SAMLResponseBuilder {
                         SAMLSSOUtil.getSAMLResponseValidityPeriod() * 60 *
                                 1000);
         response.setIssueInstant(issueInstant);
-        Assertion assertion = buildSAMLAssertion(ssoIdPConfigs, notOnOrAfter, userName);
+        Assertion assertion = buildSAMLAssertion(ssoIdPConfigs, issueInstant, notOnOrAfter, userName);
         if (ssoIdPConfigs.isDoEnableEncryptedAssertion()) {
             String domainName = MultitenantUtils.getTenantDomain(userName);
             String alias = ssoIdPConfigs.getCertAlias();
@@ -127,20 +127,21 @@ public class SAMLResponseBuilder {
      * Build SAML assertion
      *
      * @param ssoIdPConfigs
+     * @param issueInstant
      * @param notOnOrAfter
      * @param userName
      * @return Assertion object
      * @throws IdentityException
      */
-    private Assertion buildSAMLAssertion(SAMLSSOServiceProviderDO ssoIdPConfigs,
+    private Assertion buildSAMLAssertion(SAMLSSOServiceProviderDO ssoIdPConfigs, DateTime issueInstant,
                                          DateTime notOnOrAfter, String userName)
             throws IdentityException {
-        DateTime currentTime = new DateTime();
+
         Assertion samlAssertion = new AssertionBuilder().buildObject();
         samlAssertion.setID(SAMLSSOUtil.createID());
         samlAssertion.setVersion(SAMLVersion.VERSION_20);
         samlAssertion.setIssuer(SAMLSSOUtil.getIssuer());
-        samlAssertion.setIssueInstant(currentTime);
+        samlAssertion.setIssueInstant(issueInstant);
         Subject subject = new SubjectBuilder().buildObject();
         NameID nameId = new NameIDBuilder().buildObject();
         String claimValue = null;
@@ -206,7 +207,7 @@ public class SAMLResponseBuilder {
         }
 
         Conditions conditions = new ConditionsBuilder().buildObject();
-        conditions.setNotBefore(currentTime);
+        conditions.setNotBefore(issueInstant);
         conditions.setNotOnOrAfter(notOnOrAfter);
         conditions.getAudienceRestrictions().add(audienceRestriction);
         samlAssertion.setConditions(conditions);


### PR DESCRIPTION
Sending the 'response.issueInstant' to Assertion because the 'Assertion.NotBefore' value may not be after the 'response.issueInstant'.

Before the change:
```xml
<saml2p:Response IssueInstant="2016-11-17T13:07:11.382Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol">
  <saml2:Assertion IssueInstant="2016-11-17T13:07:11.383Z" Version="2.0" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
    <saml2:Conditions NotBefore="2016-11-17T13:07:11.383Z" NotOnOrAfter="2016-11-17T13:12:11.382Z"/>
  </saml2:Assertion>
</saml2p:Response>
```

After the change

```xml
<saml2p:Response IssueInstant="2016-11-17T13:07:11.383Z" Version="2.0" xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol">
  <saml2:Assertion IssueInstant="2016-11-17T13:07:11.383Z" Version="2.0" xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
    <saml2:Conditions NotBefore="2016-11-17T13:07:11.383Z" NotOnOrAfter="2016-11-17T13:12:11.382Z"/>
  </saml2:Assertion>
</saml2p:Response>
```
